### PR TITLE
Compatible with good 6.4

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var Os = require('os');
 var Util = require('util');
-var GoodReporter = require('good-reporter');
+var Squeeze = require('good-squeeze').Squeeze;
 var Hoek = require('hoek');
 var Wreck = require('wreck');
 var Stringify = require('json-stringify-safe');
@@ -14,20 +14,24 @@ var internals = {
   host: Os.hostname()
 };
 
-module.exports = internals.GoodSlack = function(events, channel, url, options) {
+module.exports = internals.GoodSlack = function(events, config) {
+  config = config || {};
+
   Hoek.assert(this.constructor === internals.GoodSlack,
     'GoodSlack must be created with new');
-  Hoek.assert(typeof channel === 'string', 'channel must be a string');
-  Hoek.assert(typeof url === 'string', 'url must be a string');
 
-  var settings = Hoek.applyToDefaults(internals.defaults, options || {});
-  settings.channel = channel;
-  settings.url = url;
+  Hoek.assert(typeof config.url === 'string', 'config.url must be a string');
 
-  GoodReporter.call(this, events, settings);
+  this._events = events;
+  this._settings = Hoek.applyToDefaults(internals.defaults, config);
 };
 
-Hoek.inherits(internals.GoodSlack, GoodReporter);
+internals.GoodSlack.prototype.init = function (stream, emitter, callback) {
+  var squeeze = Squeeze(this._events);
+  stream.pipe(squeeze).on('data', this._report.bind(this));
+
+  callback();
+};
 
 internals.codeFormat = function(data) {
   return Util.format('```\n%s\n```', data);
@@ -43,12 +47,12 @@ internals.GoodSlack.prototype._send = function(attachment) {
   });
 };
 
-internals.GoodSlack.prototype._report = function(event, eventData) {
+internals.GoodSlack.prototype._report = function(eventData) {
   var host = internals.host;
   var time = Moment.utc(eventData.timestamp).format(this._settings.format);
 
   var attachment = {
-    pretext: Util.format('`%s` event from *%s* at %s', event, host, time),
+    pretext: Util.format('`%s` event from *%s* at %s', eventData.event, host, time),
       'mrkdwn_in': ['pretext', 'text', 'fields']
   };
 
@@ -58,7 +62,7 @@ internals.GoodSlack.prototype._report = function(event, eventData) {
   // whenever message attachments cannot be shown (ie. mobile notifications,
   // desktop notifications, IRC)."
 
-  if (event === 'ops') {
+  if (eventData.event === 'ops') {
     this._send(Hoek.merge(attachment, {
       fields: [{
         title: 'Memory',
@@ -75,7 +79,7 @@ internals.GoodSlack.prototype._report = function(event, eventData) {
       }]
     }));
   }
-  else if (event === 'response') {
+  else if (eventData.event === 'response') {
     var method = eventData.method.toUpperCase();
     var query = Stringify(eventData.query);
 
@@ -87,7 +91,7 @@ internals.GoodSlack.prototype._report = function(event, eventData) {
       text: text
     }));
   }
-  else if (event === 'error') {
+  else if (eventData.event === 'error') {
     var error = eventData.error;
 
     this._send(Hoek.merge(attachment, {
@@ -101,7 +105,7 @@ internals.GoodSlack.prototype._report = function(event, eventData) {
       }]
     }));
   }
-  else if (event === 'request') {
+  else if (eventData.event === 'request') {
     var reqMethod = eventData.method.toUpperCase();
     var reqData = eventData.data;
 
@@ -136,4 +140,8 @@ internals.GoodSlack.prototype._report = function(event, eventData) {
       ]
     }));
   }
+};
+
+internals.GoodSlack.attributes = {
+  pkg: require('../package.json')
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-slack",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "repository": "git://github.com/dmacosta/good-slack",
   "description": "Slack Webhook message posting for Good process monitor",
   "main": "index.js",
@@ -10,7 +10,7 @@
   "author": "Diego Acosta",
   "license": "MIT",
   "dependencies": {
-    "good-reporter": "^3.0.1",
+    "good-squeeze": "^2.1.0",
     "hoek": "^2.10.0",
     "json-stringify-safe": "^5.0.0",
     "moment": "^2.8.4",

--- a/test/index.js
+++ b/test/index.js
@@ -120,31 +120,24 @@ describe('GoodSlack', function () {
     done();
   });
 
-  it('throws an error if missing channel', function (done) {
-    expect(function () {
-      var reporter = new GoodSlack();
-    }).to.throw('channel must be a string');
-
-    done();
-  });
-
   it('throws an error if missing url', function (done) {
     expect(function () {
-      var reporter = new GoodSlack(null, '#channel');
-    }).to.throw('url must be a string');
+      var reporter = new GoodSlack(null, {});
+    }).to.throw('config.url must be a string');
 
     done();
   });
 
   it('does not throw an error with missing options', function (done) {
-    var reporter = new GoodSlack(null, '#channel', 'https://hooks.slack.com');
+    var reporter = new GoodSlack(null, {url: 'https://hooks.slack.com'});
     expect(reporter).to.exist();
 
     done();
   });
 
   it('set options to defaults', function (done) {
-    var reporter = new GoodSlack(null, '#channel', 'https://hooks.slack.com', {
+    var reporter = new GoodSlack(null, {
+      url: 'https://hooks.slack.com',
       slack: { username: 'testing-bot' },
       format: 'lll'
     });
@@ -191,8 +184,7 @@ describe('GoodSlack', function () {
       });
 
       it('sends message on "response" event on success', function (done) {
-        var reporter = new GoodSlack({ response: '*' }, '#channel',
-          'https://hooks.slack.com');
+        var reporter = new GoodSlack({ response: '*' }, { url: 'https://hooks.slack.com'});
         var now = Date.now();
         var timeString = Moment.utc(now).format(internals.defaults.format);
         var ee = new EventEmitter();


### PR DESCRIPTION
- Removed `good-reporter` which is now deprecated
- Follows the new [Reporter interface](https://github.com/hapijs/good#reporter-interface)

This is a breaking change, as the instantiation options are not the same anymore:
```
new GoodSlack(events, {
  url: "webhook url",
  slack: {
    channel: "#general",
    // etc.
  }
});
```

This is a very rough PR: tests do not pass yet, I'd love if anyone could help me update them.