### PR TITLE
Fix fallback fields and 100% code coverage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,17 +63,19 @@ internals.GoodSlack.prototype._report = function (eventData) {
         'mrkdwn_in': ['pretext', 'text', 'fields']
     };
 
-    // TODO(dacosta) add `fallback` messages
-    //
-    // "Please note that the fallback field is required, and is displayed
-    // whenever message attachments cannot be shown (ie. mobile notifications,
-    // desktop notifications, IRC)."
-
     if (eventData.event === 'ops') {
+        var pMem = Math.round(eventData.proc.mem.rss / (1024 * 1024)) + ' Mb.';
+        var osLoad = eventData.os.load.map(function (value) {
+
+            return value.toFixed(2);
+        });
+
         this._send(Hoek.merge(attachment, {
+            fallback: Util.format('L: %s | M: %s | U: %s', osLoad[1], pMem,
+                eventData.proc.uptime),
             fields: [{
                 title: 'Memory',
-                value: Math.round(eventData.proc.mem.rss / (1024 * 1024)) + ' Mb.',
+                value: pMem,
                 short: true
             }, {
                 title: 'Uptime (seconds)',
@@ -81,7 +83,7 @@ internals.GoodSlack.prototype._report = function (eventData) {
                 short: true
             }, {
                 title: 'Load',
-                value: eventData.os.load,
+                value: osLoad.join(' | '),
                 short: true
             }]
         }));
@@ -94,18 +96,24 @@ internals.GoodSlack.prototype._report = function (eventData) {
             query, eventData.statusCode, eventData.responseTime);
 
         this._send(Hoek.merge(attachment, {
+            fallback: Util.format('%s %s %s', eventData.statusCode, method,
+                eventData.path),
             color: eventData.statusCode >= 400 ? 'danger' : 'good',
             text: text
         }));
     }
     else if (eventData.event === 'error') {
         var error = eventData.error;
+        var errorMsg = Util.format('%s: %s', error.name, error.message);
 
         this._send(Hoek.merge(attachment, {
+            fallback: errorMsg,
+            text: Util.format('*%s* %s', eventData.method.toUpperCase(),
+                eventData.url.path),
             color: 'danger',
             fields: [{
                 title: 'Error',
-                value: Util.format('%s: %s', error.name, error.message)
+                value: errorMsg
             }, {
                 title: 'Stack',
                 value: internals.codeFormat(error.stack)
@@ -115,20 +123,24 @@ internals.GoodSlack.prototype._report = function (eventData) {
     else if (eventData.event === 'request') {
         var reqMethod = eventData.method.toUpperCase();
         var reqData = eventData.data;
+        var reqDataFallback = eventData.data;
 
-        var routeText = Util.format('%s %s', reqMethod, eventData.path);
-        var requestText = Util.format('PID: %s \nRequest ID: %s',
-            eventData.pid, eventData.id);
+        var routeText = Util.format('*%s* %s', reqMethod, eventData.path);
+        var logTags = eventData.tags.join(', ');
 
         if (typeof eventData.data === 'object') {
             reqData = internals.codeFormat(Stringify(eventData.data, null, 2));
+            reqDataFallback = Stringify(eventData.data);
         }
 
         this._send(Hoek.merge(attachment, {
+            fallback: Util.format('%s %s', logTags, reqDataFallback),
+            text: routeText,
             color: eventData.tags.indexOf('error') > -1 ? 'danger' : undefined,
             fields: [
-                { title: routeText, value: requestText },
-                { title: 'Tags', value: eventData.tags.join(', ') },
+                { title: 'PID', value: eventData.pid },
+                { title: 'Request ID', value: eventData.id },
+                { title: 'Tags', value: logTags },
                 { title: 'Data', value: reqData }
             ]
         }));
@@ -136,12 +148,15 @@ internals.GoodSlack.prototype._report = function (eventData) {
     else {
         var tags = eventData.tags || [];
         var data = eventData.data;
+        var dataFallback = eventData.data;
 
         if (typeof eventData.data === 'object') {
             data = internals.codeFormat(Stringify(eventData.data, null, 2));
+            dataFallback = Stringify(eventData.data);
         }
 
         this._send(Hoek.merge(attachment, {
+            fallback: Util.format('%s %s', tags, dataFallback).trim(),
             fields: [
                 { title: 'Tags', value: tags.toString() },
                 { title: 'Data', value: data }

--- a/test/index.js
+++ b/test/index.js
@@ -138,6 +138,16 @@ it('can be created without new', function (done) {
     done();
 });
 
+it('throws an error if no config is passed', function (done) {
+
+    expect(function () {
+
+        new GoodSlack(null);
+    }).to.throw('url must be a string');
+
+    done();
+});
+
 it('throws an error if missing url', function (done) {
 
     expect(function () {
@@ -232,6 +242,7 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`response` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: '200 POST /data',
                     color: 'good',
                     text: '*POST* /data {"name":"diego"} 200 (150ms)'
                 }]
@@ -255,6 +266,7 @@ describe('_report()', function () {
             event.timestamp = now;
             event.data = { name: 'diego' };
             var reqPayload = Stringify({ name: 'diego' }, null, 2);
+            var reqPayloadFallback = Stringify({ name: 'diego' });
 
             reporter.init(stream, null, function (err) {
 
@@ -266,10 +278,15 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`request` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: Util.format('info %s', reqPayloadFallback),
+                    text: '*POST* /data',
                     fields: [{
-                        title: 'POST /data',
-                        value: 'PID: 10001 \nRequest ID: 23147901234:Machine1:73489:8uasdf98:10000'
-                    },{
+                        title: 'PID',
+                        value: '10001'
+                    }, {
+                        title: 'Request ID',
+                        value: '23147901234:Machine1:73489:8uasdf98:10000'
+                    }, {
                         title: 'Tags',
                         value: 'info'
                     }, {
@@ -307,11 +324,16 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`request` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: 'error This is a request log',
+                    text: '*POST* /data',
                     color: 'danger',
                     fields: [{
-                        title: 'POST /data',
-                        value: 'PID: 10001 \nRequest ID: 23147901234:Machine1:73489:8uasdf98:10000'
-                    },{
+                        title: 'PID',
+                        value: '10001'
+                    }, {
+                        title: 'Request ID',
+                        value: '23147901234:Machine1:73489:8uasdf98:10000'
+                    }, {
                         title: 'Tags',
                         value: 'error'
                     }, {
@@ -349,6 +371,7 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`response` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: '404 POST /data',
                     color: 'danger',
                     text: '*POST* /data {"name":"diego"} 404 (150ms)'
                 }]
@@ -380,6 +403,7 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`ops` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: 'L: 1.62 | M: 29 Mb. | U: 6',
                     fields: [{
                         title: 'Memory',
                         value:'29 Mb.',
@@ -390,7 +414,7 @@ describe('_report()', function () {
                         short: true
                     }, {
                         title: 'Load',
-                        value: [1.650390625,1.6162109375,1.65234375],
+                        value: '1.65 | 1.62 | 1.65',
                         short: true
                     }]
                 }]
@@ -428,6 +452,8 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`error` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: 'Error: Something bad had happened',
+                    text: '*GET* /search?name=diego',
                     color: 'danger',
                     fields:[{
                         title: 'Error',
@@ -466,6 +492,7 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`log` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: 'info Server started at http://localhost:3000',
                     fields: [{
                         title: 'Tags',
                         value: 'info'
@@ -501,11 +528,13 @@ describe('_report()', function () {
             });
 
             var payload = Stringify(event.data, null, 2);
+            var payloadFallback = Stringify(event.data);
 
             var data = Stringify({
                 attachments: [{
                     pretext: '`log` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: Util.format('info %s', payloadFallback),
                     fields: [{
                         title: 'Tags',
                         value: 'info'
@@ -545,6 +574,7 @@ describe('_report()', function () {
                 attachments: [{
                     pretext: '`log` event from *localhost* at ' + timeString,
                     'mrkdwn_in': ['pretext','text','fields'],
+                    fallback: 'Server started at http://localhost:3000',
                     fields: [{
                         title: 'Tags',
                         value: ''


### PR DESCRIPTION
Hey,

This PR fixes the missing fallback fields for all the events and contains a few minor fixes outlined below.

- Fallback fields are required by Slack to display messages correctly on mobile and desktop notifications. All events now include this field without any formatting.

- Code coverage was missing a test for undefined config object when invoking GoodSlack. A test for this is now included to attain 100% code coverage.

- The OS load for ops events weren't displayed correctly as it needed to be formatted as string where previously an array was passed in. Correct load values are now displayed for 1, 5 and 15 minute intervals rounded to two decimal places.

- Error events now display the request method and path as it can be difficult to identify the source if the error stack doesn't contain any relevant information.

- Formatting for log events are now fixed to use multiple fields for PID and request IDs.

- The test spec has been updated to accept the new fallback fields and other changes mentioned above with all tests passing successfully.

Thanks.