### PR TITLE
Fix duplicate messages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ internals.codeFormat = function (data) {
 
 internals.GoodSlack.prototype._send = function (attachment) {
 
-    var payload = Hoek.merge(this._config.slack, {
+    var payload = Hoek.applyToDefaults(this._config.slack, {
         attachments: [attachment]
     });
 


### PR DESCRIPTION
`Hoek.merge` mutates the first object passed to it. This causes messages to pile up in `attachments` and every successive call to `_send` sends all previous attachments from previous calls to `_send`.

I fixed this by using the non-destructive alternative to `Hoek.merge`, [`Hoek.applyToDefaults`](https://github.com/hapijs/hoek/blob/master/API.md#applytodefaultsdefaults-options-isnulloverride).

I also added a test that fails without the change from `merge` -> `applyToDefaults`.